### PR TITLE
Improved mailer and fixed deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,13 @@ language: node_js
 node_js:
   - "6"
 
-env:
-  CODECLIMATE_REPO_TOKEN: 064e61fd189c040a80866ab03d103b36190cab998577618537ea868c9e9e9e9f
+addons:
+  code_climate:
+    repo_token: 064e61fd189c040a80866ab03d103b36190cab998577618537ea868c9e9e9e9f
 
 notifications:
     slack: capstonenewgenleaders:w6aiZa947QGvQ1GpkAgWy8KL
+
+after_success:
+  - npm install -g codeclimate-test-reporter
+  - if [ "$TRAVIS_BRANCH" = "dev" ]; then codeclimate-test-reporter < coverage/lcov.info;

--- a/app/models/userModel/userModel.spec.js
+++ b/app/models/userModel/userModel.spec.js
@@ -1,7 +1,11 @@
+const mongoose = require('mongoose');
 let crypto = require('../../utilities/crypto/crypto')();
 let UserModel = require('./userModel')({
     crypto
 });
+
+// Replace deprecated library during test
+mongoose.Promise = require('bluebird');
 
 describe('user model', function(){
 
@@ -14,7 +18,6 @@ describe('user model', function(){
         });
     });
 
-    // TODO: Remove deprecation warning during tests for mongoose
     describe('require validation', function(){
 
         it ('should be invalid if username is empty', function(done){

--- a/app/utilities/mailer/mailer.js
+++ b/app/utilities/mailer/mailer.js
@@ -1,21 +1,51 @@
 const nodemailer = require('nodemailer');
+const htmlToText = require('nodemailer-html-to-text').htmlToText;
 const q = require('q');
 const email_config = require('config').get('email_server');
 
-// TODO: Allow for services (GMail, Outlook, SendGrid) to be used in place of standard host url
-let transporter = nodemailer.createTransport({
-    pool: email_config.get('pooling'),
-    host: email_config.get('host'),
-    secure: email_config.get('secure'),
-    auth: {
-        user: email_config.get('authentication.username'),
-        pass: email_config.get('authentication.password')
-    },
-    tls: {
-        ciphers: email_config.get('tls.ciphers')
-    }
+var connected;
+
+// Configuration for the nodemailer transporter
+let configuration = {};
+
+/* 
+* This connects to a service (Outlook, Gmail, Sendgrid etc.) if a service is set in the config.
+* If unavailable, one must configure a host along with port to connect directly via smtp.
+*/
+if (emailSettings.has('service')) {
+    configuration.service = email_config.get('service');
+}
+else {
+    configuration.host = email_config.get('host');
+    configuration.secure = email_config.get('secure');
+}
+
+configuration.pool = email_config.get('pooling'); // Use thread pooling for email
+configuration.auth = {};
+configuration.auth.user = email_config.get('authentication.username');
+configuration.auth.pass = email_config.get('authentication.password');
+
+if (config.has('tls.ciphers')) {
+    configuration.tls = {};
+    configuration.tls.ciphers = email_config.get('tls.ciphers');
+}
+
+let transporter = nodemailer.createTransport(configuration);
+transporter.use('compile', htmlToText()); //Sets the text field of an email based on html
+  
+// Verfiy whether mailer is ready to receive emails or not
+transporter.verify(function(error, success) {
+   if (error) {
+        console.log("Failed to start mail service with " + error);
+        console.log("Mail features will be disabled till configuration is corrected")
+        connected = false;
+   } else {
+        console.log('Mail service is ready to receive messages');
+        connected = true;
+   }
 });
 
+// Set the display name and senders address for your server
 let mailOptions = {
     from: {
         name: email_config.get('display_name'),
@@ -30,6 +60,11 @@ module.exports = function(){
         sendMail: function(email, subject, html) {
             var deferred = q.defer();
 
+            if (!connected)
+            {
+                deferred.reject("Mail service is currently not active");
+            }
+            
             mailOptions.to = email;
             mailOptions.subject = subject;
             mailOptions.html = html;

--- a/app/utilities/mailer/mailer.js
+++ b/app/utilities/mailer/mailer.js
@@ -12,7 +12,7 @@ let configuration = {};
 * This connects to a service (Outlook, Gmail, Sendgrid etc.) if a service is set in the config.
 * If unavailable, one must configure a host along with port to connect directly via smtp.
 */
-if (emailSettings.has('service')) {
+if (email_config.has('service') && email_config.get('service') !== null) {
     configuration.service = email_config.get('service');
 }
 else {
@@ -25,7 +25,11 @@ configuration.auth = {};
 configuration.auth.user = email_config.get('authentication.username');
 configuration.auth.pass = email_config.get('authentication.password');
 
-if (config.has('tls.ciphers')) {
+/* 
+* If custom ciphers are required, be sure to specify them in the config file 
+* (e.g outlook smtp requires the SSLv3 ciphers)
+*/
+if (email_config.has('tls.ciphers') && email_config.get('tls.ciphers') !== null) {
     configuration.tls = {};
     configuration.tls.ciphers = email_config.get('tls.ciphers');
 }
@@ -35,14 +39,14 @@ transporter.use('compile', htmlToText()); //Sets the text field of an email base
   
 // Verfiy whether mailer is ready to receive emails or not
 transporter.verify(function(error, success) {
-   if (error) {
-        console.log("Failed to start mail service with " + error);
-        console.log("Mail features will be disabled till configuration is corrected")
-        connected = false;
-   } else {
-        console.log('Mail service is ready to receive messages');
-        connected = true;
-   }
+    if (error) {
+            console.log("Failed to start mail service with " + error);
+            console.log("Mail features will be disabled till configuration is corrected")
+            connected = false;
+    } else {
+            console.log('Mail service is ready to receive messages');
+            connected = true;
+    }
 });
 
 // Set the display name and senders address for your server

--- a/config/default.json
+++ b/config/default.json
@@ -13,7 +13,7 @@
         },
         "tls": {
             // Use if custom ciphers are required for TLS in your connection else don't touch
-            "ciphers": ""
+            "ciphers": null
         },
         // The displayed name for emails from this server
         "display_name": "Time Series Support",
@@ -24,7 +24,7 @@
         // Should be false when using port 587 and true when using port 465
         "secure": false,
         // Define only if you are using OAUTH2 to connect to a service. For a list of available services check nodemailer (https://nodemailer.com/smtp/well-known/)
-        "service": ""
+        "service": null
     },
     // Your secret token, used for application encryption protocols. If you think it has been compromised, please regenerate a new one.
     "secret": "06d7366ebaaa2b86a1ace069792a29e6aa63e550d49f5744d8f13f17b456daeca15e935e99fa9a696e4251ede68140cae185b88f35199bb978280520d42dcd86" 

--- a/config/test.json
+++ b/config/test.json
@@ -1,0 +1,4 @@
+{
+    // The secret token used for testing, do not alter
+    "secret": "06d7366ebaaa2b86a1ace069792a29e6aa63e550d49f5744d8f13f17b456daeca15e935e99fa9a696e4251ede68140cae185b88f35199bb978280520d42dcd86"
+} 

--- a/package.json
+++ b/package.json
@@ -7,10 +7,16 @@
     "title": "Saffron WebAPI Endpoints",
     "url": "http://localhost:3000"
   },
+  "nyc": {
+    "exclude": [
+      "**/*.spec.js",
+      "**/*.mock.js"
+    ]
+  },
   "scripts": {
     "start": "set NODE_ENV=dev && node index.js",
     "start-prod": "set NODE_ENV=prod node index.js",
-    "test": "jasmine"
+    "test": "nyc --reporter=lcov jasmine"
   },
   "repository": {
     "type": "git",
@@ -37,6 +43,7 @@
     "cors": "^2.8.3",
     "eslint": "^4.0.0",
     "jasmine": "^2.6.0",
+    "nyc": "^11.0.2",
     "request": "^2.81.0",
     "valid-url": "^1.0.9"
   }

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     ]
   },
   "scripts": {
-    "start": "set NODE_ENV=dev && node index.js",
-    "start-prod": "set NODE_ENV=prod node index.js",
-    "test": "nyc --reporter=lcov jasmine"
+    "start": "set NODE_ENV=dev&&node index.js",
+    "start-prod": "set NODE_ENV=prod&&node index.js",
+    "test": "set NODE_ENV=test&&nyc --reporter=lcov jasmine"
   },
   "repository": {
     "type": "git",
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/TimeSeriesPrediction/time-series-server#readme",
   "dependencies": {
+    "bluebird": "^3.5.0",
     "body-parser": "^1.17.2",
     "config": "^1.26.1",
     "crypto-js": "^3.1.9-1",


### PR DESCRIPTION
- Improved mailer to use configuration files and select between services or custom http
- Added Istanbul test coverage to repository using code climate + nyc
- Added test config file so that same secret can always be used for testing if changed (Will also add mailtrap.io as the testing SMTP eventually)
- Fixed mongoose deprecation warnings by switching promises to bluebird (the recommended promise library) as q errors out during the validation calls ( closes #24 )