### PR TITLE
Issue #17 - Extend token expiry on active use

### DIFF
--- a/app/routes/accountApi/accountApi.js
+++ b/app/routes/accountApi/accountApi.js
@@ -31,7 +31,7 @@ module.exports = function AccountApi({
         var password = req.body.password;
 
         if (!username || !password){
-            res.status(401).json({ message: 'Authorisation has been denied for this request'});
+            res.status(401).send({ message: 'Authorisation has been denied for this request'});
             return;
         }
     
@@ -41,14 +41,14 @@ module.exports = function AccountApi({
                 var ip = requestIp.getClientIp(req);
 
                 authentication.generateAuthToken(user, ip).then(function(token){
-                    res.status(200).json({
+                    res.status(200).send({
                         authToken: token
                     });
                 });
             }
         })
         .catch(function(){
-            res.status(401).json({ message: 'Authorisation has been denied for this request'});
+            res.status(401).send({ message: 'Authorisation has been denied for this request'});
         });
 
     });
@@ -81,7 +81,8 @@ module.exports = function AccountApi({
         .then(function(token){
             emailService.sendForgottenPassword(email, token)
             .then(function(){
-                res.status(200).json({ message: 'An email was sent to ' + email });
+                res.data.message = 'An email was sent to ' + email;
+                res.status(200).send(res.data);
             })
             .catch(function(error){
                 res.status(500).send();
@@ -126,10 +127,11 @@ module.exports = function AccountApi({
         
         usersService.setNewPassword(token, password)
         .then(function(){
-            res.status(200).json({ message: 'Your password was successfully changed' });
+            res.data.message = 'Your password was successfully changed';
+            res.status(200).send(res.data);
         })
         .catch(function(){
-            res.status(401).json({ message: 'Password reset is invalid or expired' });
+            res.status(401).send({ message: 'Password reset is invalid or expired' });
         });
     });
 

--- a/app/routes/usersApi/usersApi.js
+++ b/app/routes/usersApi/usersApi.js
@@ -25,7 +25,8 @@ module.exports = function UsersApi ({
         
         usersService.getUsers()
         .then(function(users){
-            res.status(200).json(users);
+            res.data.users = users;
+            res.status(200).send(res.data);
         })
         .catch(function(err){
             res.status(500).send(err)
@@ -48,7 +49,8 @@ module.exports = function UsersApi ({
     * @apiSuccess {String}  user.resetPasswordExpires Password reset token expiry
     */
     router.get('/profile',authentication.authenticate, (req, res) => {
-        res.status(200).json(req.user);
+        res.data.user = req.user;
+        res.status(200).send(res.data);
     });
 
     /**
@@ -71,7 +73,8 @@ module.exports = function UsersApi ({
     router.get('/:id',authentication.authenticate, (req, res) => {
         usersService.getUserById(req.params.id)
         .then(function(user){
-            res.status(200).json(user);
+            res.data.user = user;
+            res.status(200).send(res.data);
         })
         .catch(function(err){
             res.status(500).send(err);
@@ -103,9 +106,8 @@ module.exports = function UsersApi ({
 
         usersService.addUser(name, password, email)
         .then(function(){
-            res.status(201).json({
-                message: 'User created successfully'
-            });
+            res.data.message = 'User created successfully';
+            res.status(201).send(res.data);
         })
         .catch(function(error){
             res.status(500).send(error);

--- a/app/services/authentication/authentication.js
+++ b/app/services/authentication/authentication.js
@@ -26,6 +26,8 @@ module.exports = function Authentication({
              throw new UnauthorisedException();
           }
 
+          res.data.authToken = crypto.encrypt(JSON.stringify(new Token(user, ip)));
+
           req.user = user;
         }
         catch(error){

--- a/app/services/authentication/authentication.spec.js
+++ b/app/services/authentication/authentication.spec.js
@@ -38,7 +38,8 @@ describe('authentication service', function(){
 
         mockRes = {
             status: function(){},
-            json: function(){}
+            json: function(){},
+            data: {}
         }
 
         spyOn(mockRes, 'status').and.returnValue(mockRes);

--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ const app = express();
 // Adds cross origin support between client and server
 app.use(cors());
 
+//Sets up response data object for use in other middleware
 app.use((req, res, next) => {
     res.data = {};
     next();

--- a/index.js
+++ b/index.js
@@ -54,6 +54,11 @@ const app = express();
 // Adds cross origin support between client and server
 app.use(cors());
 
+app.use((req, res, next) => {
+    res.data = {};
+    next();
+})
+
 // Parsers for POST data
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));


### PR DESCRIPTION
Resets the expiry of the authentication token when it is being used.

Responding to requests should change a little after this is merged. response.data is initialised to an empty object and then the response data is added to it, and this object is returned. This way any middleware can add data to the response. eg:
```
response.data.someData = 'whatevs';
response.status(200).send(response.data);
```