### PR TITLE
removed adminOnly auth on get modules

### DIFF
--- a/app/routes/modulesApi/modulesApi.js
+++ b/app/routes/modulesApi/modulesApi.js
@@ -20,7 +20,7 @@ module.exports = function ModulesApi ({
     * @apiSuccess {String}  modules.name Name
     * @apiSuccess {String}  modules.code Module Code
     */
-    router.get('/', authorisation.adminOnly, (req, res) => {
+    router.get('/', (req, res) => {
         
         modulesService.getModules()
         .then(function(modules){


### PR DESCRIPTION
Removed this as it doesn't make sense that only admins can see what modules there are. Also, I need it to fix a bug